### PR TITLE
feat: adding auto deploy through ssh

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,25 @@
+name: Project Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update-server:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Run remote command
+        run: |
+          ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "cd projects/hub-community-frontend && make update"


### PR DESCRIPTION
🔧 Add GitHub Action to Remotely Update Project via SSH

✅ What this PR does

This pull request introduces a GitHub Action that connects to a remote server via SSH to execute deployment commands for the project. The primary commands executed are:
```
cd projects/<name-of-the-app>
make update
```

🚀 How it works
	•	Sets up SSH using a private key stored in GitHub Secrets (SSH_PRIVATE_KEY)
	•	Connects to the remote server defined by SSH_HOST and SSH_USER
	•	Navigates to the project directory and runs make update to apply updates

🔒 Security
	•	SSH private key is stored securely in GitHub Secrets
	•	Only the github_runner user on the server is used for automation
	•	SSH login is restricted to key-based authentication

📝 Setup required on server
	•	A new user (github_runner) must be created on the server
	•	The SSH public key has been added to /home/github_runner/.ssh/authorized_keys
	•	The server must allow key-based SSH login for that user

📦 Files added
	•	.github/workflows/update-project.yml: defines the new GitHub Action

🧪 How to test
	1.	Merge this PR to main
	2.	Push any change to main or trigger the workflow manually
	3.	Monitor the “Remote Project Update” workflow on GitHub Actions