### PR TITLE
feat: Auth Modal com Zod, react-hook-form e toast feedback

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,11 @@
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import type React from 'react';
+import { Toaster as SonnerToaster } from 'sonner';
 
 import { PageTransitionProvider } from '@/components/animations';
 import { ApolloProviderWrapper } from '@/components/apollo-provider';
+import { ErrorBoundary } from '@/components/error-boundary';
 import { FirebaseProvider } from '@/components/firebase-provider';
 import { Footer } from '@/components/footer';
 import { LogoutModalWrapper } from '@/components/logout-modal-wrapper';
@@ -60,10 +62,13 @@ export default function RootLayout({
                     disableTransitionOnChange
                   >
                     <Navigation />
-                    <PageTransitionProvider>
-                      {children}
-                    </PageTransitionProvider>
+                    <ErrorBoundary>
+                      <PageTransitionProvider>
+                        {children}
+                      </PageTransitionProvider>
+                    </ErrorBoundary>
                     <Toaster />
+                    <SonnerToaster richColors position="top-right" />
                     <Footer />
                   </ThemeProvider>
                 </FilterProvider>

--- a/src/components/admin/batch-form-dialog.tsx
+++ b/src/components/admin/batch-form-dialog.tsx
@@ -20,27 +20,15 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import {
+  batchSchema,
+  type BatchFormValues,
+} from '@/lib/schemas';
 import { Batch } from '@/lib/types';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { format } from 'date-fns';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import * as z from 'zod';
-
-const batchSchema = z.object({
-  batch_number: z.coerce.number().min(1, 'Número do lote obrigatório.'),
-  value: z.coerce.number().min(0, 'Valor deve ser positivo.'),
-  max_quantity: z.coerce
-    .number()
-    .min(1, 'Quantidade deve ser informada.')
-    .optional(),
-  valid_from: z.string().min(1, 'Data de início obrigatória.'),
-  valid_until: z.string().min(1, 'Data de fim obrigatória.'),
-  enabled: z.boolean().default(true),
-  half_price_eligible: z.boolean().default(false),
-});
-
-type BatchFormValues = z.infer<typeof batchSchema>;
 
 // Extending Batch type to match user request locally if needed, or assuming updated types
 interface ExtendedBatch extends Batch {

--- a/src/components/admin/community-form-dialog.tsx
+++ b/src/components/admin/community-form-dialog.tsx
@@ -22,23 +22,19 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/hooks/use-toast';
 import { CREATE_COMMUNITY, GET_COMMUNITIES } from '@/lib/queries';
+import {
+  createCommunitySchema,
+  generateSlugFromTitle,
+  type CreateCommunityFormValues,
+} from '@/lib/schemas';
 import { CreateCommunityResponse } from '@/lib/types';
 import { useMutation } from '@apollo/client';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
-import * as z from 'zod';
-
-const communitySchema = z.object({
-  title: z.string().min(2, 'O título deve ter pelo menos 2 caracteres.'),
-  slug: z.string().min(2, 'O slug é obrigatório.'),
-  short_description: z.string().optional(),
-});
-
-type CommunityFormValues = z.infer<typeof communitySchema>;
 
 interface CommunityFormDialogProps {
-  onSave: (community: any) => void;
+  onSave: (community: CreateCommunityResponse['createCommunity']) => void;
   trigger?: React.ReactNode;
 }
 
@@ -56,8 +52,8 @@ export function CommunityFormDialog({
     }
   );
 
-  const form = useForm<CommunityFormValues>({
-    resolver: zodResolver(communitySchema),
+  const form = useForm<CreateCommunityFormValues>({
+    resolver: zodResolver(createCommunitySchema),
     defaultValues: {
       title: '',
       slug: '',
@@ -67,16 +63,10 @@ export function CommunityFormDialog({
 
   const generateSlug = () => {
     const title = form.getValues('title');
-    const slug = title
-      .toLowerCase()
-      .normalize('NFD')
-      .replace(/[\u0300-\u036f]/g, '')
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/(^-|-$)+/g, '');
-    form.setValue('slug', slug);
+    form.setValue('slug', generateSlugFromTitle(title));
   };
 
-  const onSubmit = async (data: CommunityFormValues) => {
+  const onSubmit = async (data: CreateCommunityFormValues) => {
     try {
       const { data: responseData } = await createCommunity({
         variables: {

--- a/src/components/admin/event-form.tsx
+++ b/src/components/admin/event-form.tsx
@@ -40,42 +40,17 @@ import {
   X,
 } from 'lucide-react';
 import Image from 'next/image';
+import {
+  createEventSchema,
+  type CreateEventFormValues,
+} from '@/lib/schemas';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import * as z from 'zod';
-
-const eventSchema = z.object({
-  title: z.string().min(2, {
-    message: 'O título deve ter pelo menos 2 caracteres.',
-  }),
-  slug: z.string().min(2, {
-    message: 'O slug deve ter pelo menos 2 caracteres.',
-  }),
-  start_date: z.string({
-    required_error: 'A data de início é obrigatória.',
-  }),
-  end_date: z.string({
-    required_error: 'A data de término é obrigatória.',
-  }),
-  max_slots: z.coerce.number().min(1, {
-    message: 'O número de vagas deve ser pelo menos 1.',
-  }),
-  pixai_token_integration: z.string().optional(),
-  is_online: z.boolean().optional(),
-  call_link: z.string().optional(),
-  description: z.any().optional(), // Complex type, validating as any for now
-  location: z.any().optional(), // Stores the ID or object during interaction
-  communityId: z.string().optional(),
-  talks: z.array(z.any()).optional(),
-  products: z.array(z.any()).optional(),
-});
-
-type EventFormValues = z.infer<typeof eventSchema>;
 
 interface EventFormProps {
-  initialData?: EventFormValues & { id?: string }; // Adjust based on actual data structure
-  onSubmit: (data: EventFormValues) => Promise<string | undefined>;
+  initialData?: CreateEventFormValues & { id?: string };
+  onSubmit: (data: CreateEventFormValues) => Promise<string | undefined>;
   isLoading?: boolean;
 }
 
@@ -208,8 +183,8 @@ export function EventForm({
     if (fileInputRef.current) fileInputRef.current.value = '';
   };
 
-  const form = useForm<EventFormValues>({
-    resolver: zodResolver(eventSchema),
+  const form = useForm<CreateEventFormValues>({
+    resolver: zodResolver(createEventSchema),
     defaultValues: initialData || {
       title: '',
       slug: '',
@@ -302,7 +277,7 @@ export function EventForm({
     return undefined;
   };
 
-  const handleFormSubmit = async (data: EventFormValues) => {
+  const handleFormSubmit = async (data: CreateEventFormValues) => {
     const eventId = await onSubmit(data);
 
     // Upload cover image if a new file was selected

--- a/src/components/admin/location-form-dialog.tsx
+++ b/src/components/admin/location-form-dialog.tsx
@@ -27,6 +27,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import {
+  locationSchema,
+  type LocationFormValues,
+} from '@/lib/schemas';
 import { CREATE_LOCATION, GET_LOCATIONS } from '@/lib/queries';
 import { EventLocation } from '@/lib/types';
 import regionAndCities from '@/utils/regionAndCities.json';
@@ -34,19 +38,6 @@ import { useMutation } from '@apollo/client';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import * as z from 'zod';
-
-const locationSchema = z.object({
-  title: z.string().min(2, 'O título deve ter pelo menos 2 caracteres.'),
-  region: z.string().min(2, 'A região é obrigatória.'),
-  latitude: z.coerce.number().optional(),
-  longitude: z.coerce.number().optional(),
-  google_maps_url: z.string().url('URL inválida').optional().or(z.literal('')),
-  full_address: z.string().min(5, 'O endereço deve ser completo.'),
-  city: z.string().min(2, 'A cidade é obrigatória.'),
-});
-
-type LocationFormValues = z.infer<typeof locationSchema>;
 
 interface LocationFormDialogProps {
   onSave: (location: EventLocation) => void;

--- a/src/components/admin/product-form-dialog.tsx
+++ b/src/components/admin/product-form-dialog.tsx
@@ -21,19 +21,15 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import {
+  productSchema,
+  type ProductFormValues,
+} from '@/lib/schemas';
 import { Batch, Product } from '@/lib/types';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Pencil, Plus, Trash } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import * as z from 'zod';
-
-const productSchema = z.object({
-  name: z.string().min(2, 'O nome do produto é obrigatório.'),
-  enabled: z.boolean().default(true),
-});
-
-type ProductFormValues = z.infer<typeof productSchema>;
 
 // Extended definitions to match user request locally
 interface ExtendedBatch extends Batch {

--- a/src/components/admin/speaker-form-dialog.tsx
+++ b/src/components/admin/speaker-form-dialog.tsx
@@ -22,19 +22,15 @@ import { Input } from '@/components/ui/input';
 import { RichTextEditor } from '@/components/ui/rich-text-editor';
 import { useToast } from '@/hooks/use-toast';
 import { CREATE_SPEAKER, GET_SPEAKERS } from '@/lib/queries';
+import {
+  speakerSchema,
+  type SpeakerFormValues,
+} from '@/lib/schemas';
 import { CreateSpeakerResponse, Speaker } from '@/lib/types';
 import { useMutation } from '@apollo/client';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
-import * as z from 'zod';
-
-const speakerSchema = z.object({
-  name: z.string().min(2, 'O nome deve ter pelo menos 2 caracteres.'),
-  biography: z.any().optional(), // Rich Text JSON
-});
-
-type SpeakerFormValues = z.infer<typeof speakerSchema>;
 
 interface SpeakerFormDialogProps {
   onSave: (speaker: Speaker) => void;

--- a/src/components/admin/talk-form-dialog.tsx
+++ b/src/components/admin/talk-form-dialog.tsx
@@ -26,6 +26,10 @@ import { RichTextEditor } from '@/components/ui/rich-text-editor';
 import { useToast } from '@/hooks/use-toast';
 import { CREATE_TALK, GET_SPEAKERS, UPDATE_TALK } from '@/lib/queries';
 import {
+  talkSchema,
+  type TalkFormValues,
+} from '@/lib/schemas';
+import {
   CreateTalkResponse,
   Speaker,
   SpeakersResponse,
@@ -37,18 +41,6 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { Plus, User, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import * as z from 'zod';
-
-const talkSchema = z.object({
-  title: z.string().min(2, 'O título é obrigatório.'),
-  subtitle: z.string().optional(),
-  description: z.any().optional(),
-  occur_date: z.string().min(1, 'A data é obrigatória.'),
-  room_description: z.string().optional(),
-  speakerIds: z.array(z.string()).default([]),
-});
-
-type TalkFormValues = z.infer<typeof talkSchema>;
 
 interface TalkInput extends Omit<Talk, 'speakers'> {
   speakerIds: string[];

--- a/src/components/admin/voting-option-form-dialog.tsx
+++ b/src/components/admin/voting-option-form-dialog.tsx
@@ -3,7 +3,6 @@
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import * as z from 'zod';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -26,15 +25,11 @@ import {
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/hooks/use-toast';
+import {
+  votingOptionSchema,
+  type VotingOptionFormValues,
+} from '@/lib/schemas';
 import { VotingOption } from '@/lib/types';
-
-const optionSchema = z.object({
-  name: z.string().min(2, 'O nome é obrigatório.'),
-  description: z.string().optional(),
-  pitch_order: z.coerce.number().min(1, 'A ordem é obrigatória.'),
-});
-
-type OptionFormValues = z.infer<typeof optionSchema>;
 
 interface VotingOptionFormDialogProps {
   onSave: (option: any) => void;
@@ -55,8 +50,8 @@ export function VotingOptionFormDialog({
   const [saving, setSaving] = useState(false);
   const { toast } = useToast();
 
-  const form = useForm<OptionFormValues>({
-    resolver: zodResolver(optionSchema),
+  const form = useForm<VotingOptionFormValues>({
+    resolver: zodResolver(votingOptionSchema),
     defaultValues: {
       name: initialData?.name || '',
       description: initialData?.description || '',
@@ -64,7 +59,7 @@ export function VotingOptionFormDialog({
     },
   });
 
-  const onSubmit = async (data: OptionFormValues) => {
+  const onSubmit = async (data: VotingOptionFormValues) => {
     try {
       setSaving(true);
       let currentSessionId = sessionId;

--- a/src/components/admin/voting-session-form.tsx
+++ b/src/components/admin/voting-session-form.tsx
@@ -5,7 +5,6 @@ import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import * as z from 'zod';
 import { Plus, Trash2 } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
@@ -30,23 +29,13 @@ import {
 } from '@/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { GET_EVENTS } from '@/lib/queries';
+import {
+  votingSessionSchema,
+  type VotingSessionFormValues,
+} from '@/lib/schemas';
 import { VotingOption, VotingSessionInput } from '@/lib/types';
 import { VotingOptionFormDialog } from '@/components/admin/voting-option-form-dialog';
 import { useToast } from '@/hooks/use-toast';
-
-const votingSessionSchema = z.object({
-  title: z.string().min(2, {
-    message: 'O título deve ter pelo menos 2 caracteres.',
-  }),
-  description: z.string().optional(),
-  event_id: z.string().optional(),
-  status: z.enum(['open', 'closed', 'archived']),
-  max_votes_per_user: z.coerce.number().min(1, {
-    message: 'O número de votos por usuário deve ser pelo menos 1.',
-  }),
-});
-
-type VotingSessionFormValues = z.infer<typeof votingSessionSchema>;
 
 export interface VotingSessionFormProps {
   initialData?: VotingSessionFormValues & {

--- a/src/components/auth-modal.tsx
+++ b/src/components/auth-modal.tsx
@@ -1,9 +1,12 @@
 'use client';
 
+import { zodResolver } from '@hookform/resolvers/zod';
+import { ApolloError } from '@apollo/client';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
 
-import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -12,12 +15,71 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useAuth } from '@/contexts/auth-context';
-import type { SignInInput, SignUpInput } from '@/lib/types';
+import {
+  resetPasswordSchema,
+  signInSchema,
+  signUpSchema,
+  type ResetPasswordFormValues,
+  type SignInFormValues,
+  type SignUpFormValues,
+} from '@/lib/schemas';
 import { Eye, EyeOff, Loader2, Lock, Mail, Phone, User } from 'lucide-react';
+
+const ERROR_MESSAGES: Record<string, string> = {
+  'Email or Username are already taken': 'Email ou username já está em uso.',
+  'Invalid identifier or password': 'Email/username ou senha inválidos.',
+  'Error signing in: Invalid identifier or password': 'Email/username ou senha inválidos.',
+  'Your account email is not confirmed': 'Confirme seu email antes de fazer login.',
+  'Error signing in: Your account email is not confirmed': 'Confirme seu email antes de fazer login.',
+  'Too many attempts': 'Muitas tentativas. Aguarde alguns minutos.',
+  'Too many requests': 'Muitas tentativas. Aguarde alguns minutos.',
+  'User not found': 'Usuário não encontrado.',
+  'Invalid email': 'Email inválido.',
+  'Invalid password': 'Senha incorreta.',
+  'Invalid credentials': 'Credenciais inválidas.',
+  'Email already taken': 'Este email já está em uso.',
+  'Username already taken': 'Este username já está em uso.',
+  'Email not found': 'Email não encontrado.',
+  'Error on try POST': 'Erro ao processar. Tente novamente.',
+};
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  let message = '';
+
+  if (error instanceof ApolloError) {
+    message = error.graphQLErrors?.[0]?.message || '';
+    if (!message && error.networkError) {
+      return 'Erro de conexão. Verifique sua internet.';
+    }
+  } else if (error instanceof Error) {
+    message = error.message;
+  }
+
+  if (!message) return fallback;
+
+  if (ERROR_MESSAGES[message]) {
+    return ERROR_MESSAGES[message];
+  }
+
+  for (const [key, value] of Object.entries(ERROR_MESSAGES)) {
+    if (message.includes(key)) {
+      return value;
+    }
+  }
+
+  return fallback;
+}
 
 interface AuthModalProps {
   isOpen: boolean;
@@ -29,95 +91,85 @@ export function AuthModal({ isOpen, onClose, redirectUrl }: AuthModalProps) {
   const { signIn, signUp, forwardPassword, isLoading } = useAuth();
   const router = useRouter();
   const [activeTab, setActiveTab] = useState('signin');
-  const [error, setError] = useState('');
-  const [success, setSuccess] = useState('');
 
   // Password visibility
   const [showSignInPassword, setShowSignInPassword] = useState(false);
   const [showSignUpPassword, setShowSignUpPassword] = useState(false);
 
+  // Email confirmation
+  const [showEmailConfirmation, setShowEmailConfirmation] = useState(false);
+  const [confirmationEmail, setConfirmationEmail] = useState('');
+
   // Sign In Form
-  const [signInData, setSignInData] = useState<SignInInput>({
-    identifier: '',
-    password: '',
+  const signInForm = useForm<SignInFormValues>({
+    resolver: zodResolver(signInSchema),
+    defaultValues: { identifier: '', password: '' },
   });
 
   // Sign Up Form
-  const [signUpData, setSignUpData] = useState<SignUpInput>({
-    email: '',
-    name: '',
-    password: '',
-    username: '',
-    phone: '',
+  const signUpForm = useForm<SignUpFormValues>({
+    resolver: zodResolver(signUpSchema),
+    defaultValues: { email: '', name: '', password: '', username: '', phone: '' },
   });
 
-  // Password Reset
-  const [resetEmail, setResetEmail] = useState('');
-  const [showEmailConfirmation, setShowEmailConfirmation] = useState(false);
+  // Reset Password Form
+  const resetForm = useForm<ResetPasswordFormValues>({
+    resolver: zodResolver(resetPasswordSchema),
+    defaultValues: { email: '' },
+  });
 
-  const handleSignIn = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError('');
-    setSuccess('');
-
+  const handleSignIn = async (data: SignInFormValues) => {
     try {
-      await signIn(signInData);
-      setSuccess('Login realizado com sucesso!');
+      await signIn(data);
+      toast.success('Bem-vindo(a) de volta!');
       setTimeout(() => {
         onClose();
-        setSuccess('');
-        setSignInData({ identifier: '', password: '' });
+        signInForm.reset();
         if (redirectUrl) {
           router.push(redirectUrl);
         }
-      }, 1500);
+      }, 1000);
     } catch (error) {
-      setError('Erro ao fazer login. Verifique suas credenciais.');
+      const message = getErrorMessage(error, 'Erro ao fazer login. Verifique suas credenciais.');
+      toast.error(message);
       console.error('Sign in error:', error);
     }
   };
 
-  const handleSignUp = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError('');
-    setSuccess('');
-
+  const handleSignUp = async (data: SignUpFormValues) => {
     try {
-      await signUp(signUpData);
+      await signUp(data);
+      setConfirmationEmail(data.email);
       setShowEmailConfirmation(true);
-      setSuccess('Conta criada com sucesso!');
+      toast.success('Conta criada com sucesso!');
     } catch (error) {
-      setError('Erro ao criar conta. Tente novamente.');
+      const message = getErrorMessage(error, 'Erro ao criar conta. Tente novamente.');
+      toast.error(message);
       console.error('Sign up error:', error);
     }
   };
 
-  const handlePasswordReset = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError('');
-    setSuccess('');
-
+  const handlePasswordReset = async (data: ResetPasswordFormValues) => {
     try {
-      await forwardPassword(resetEmail);
-      setSuccess('Email de recuperação enviado!');
+      await forwardPassword(data.email);
+      toast.success('Email de recuperação enviado!');
       setTimeout(() => {
-        setResetEmail('');
-        setSuccess('');
+        resetForm.reset();
       }, 2000);
     } catch (error) {
-      setError('Erro ao enviar email de recuperação.');
+      const message = getErrorMessage(error, 'Erro ao enviar email de recuperação.');
+      toast.error(message);
       console.error('Password reset error:', error);
     }
   };
 
   const handleClose = () => {
-    setError('');
-    setSuccess('');
     setActiveTab('signin');
-    setSignInData({ identifier: '', password: '' });
-    setSignUpData({ email: '', name: '', password: '', username: '', phone: '' });
-    setResetEmail('');
+    signInForm.reset();
+    signUpForm.reset();
+    resetForm.reset();
     setShowEmailConfirmation(false);
+    setConfirmationEmail('');
     setShowSignInPassword(false);
     setShowSignUpPassword(false);
     onClose();
@@ -153,7 +205,7 @@ export function AuthModal({ isOpen, onClose, redirectUrl }: AuthModalProps) {
                   </h3>
                   <div className="mt-2 text-sm text-green-700">
                     <p>
-                      Enviamos um email para <strong>{signUpData.email}</strong>{' '}
+                      Enviamos um email para <strong>{confirmationEmail}</strong>{' '}
                       com um link para confirmar sua conta. Verifique sua caixa
                       de entrada e clique no link para ativar sua conta.
                     </p>
@@ -166,13 +218,7 @@ export function AuthModal({ isOpen, onClose, redirectUrl }: AuthModalProps) {
                       onClick={() => {
                         setShowEmailConfirmation(false);
                         setActiveTab('signin');
-                        setSignUpData({
-                          email: '',
-                          name: '',
-                          password: '',
-                          username: '',
-                          phone: '',
-                        });
+                        signUpForm.reset();
                       }}
                       variant="outline"
                       size="sm"
@@ -187,230 +233,248 @@ export function AuthModal({ isOpen, onClose, redirectUrl }: AuthModalProps) {
 
           {/* Sign In Tab */}
           <TabsContent value="signin" className="space-y-4">
-            <form onSubmit={handleSignIn} className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="signin-identifier">Email ou Username</Label>
-                <div className="relative">
-                  <User className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                  <Input
-                    id="signin-identifier"
-                    type="text"
-                    placeholder="seu@email.com ou username"
-                    value={signInData.identifier}
-                    onChange={e =>
-                      setSignInData({
-                        ...signInData,
-                        identifier: e.target.value,
-                      })
-                    }
-                    className="pl-10"
-                    required
-                  />
-                </div>
-              </div>
+            <Form {...signInForm}>
+              <form onSubmit={signInForm.handleSubmit(handleSignIn)} className="space-y-4">
+                <FormField
+                  control={signInForm.control}
+                  name="identifier"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Email ou Username</FormLabel>
+                      <FormControl>
+                        <div className="relative">
+                          <User className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+                          <Input
+                            placeholder="seu@email.com ou username"
+                            className="pl-10"
+                            {...field}
+                          />
+                        </div>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
 
-              <div className="space-y-2">
-                <Label htmlFor="signin-password">Senha</Label>
-                <div className="relative">
-                  <Lock className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                  <Input
-                    id="signin-password"
-                    type={showSignInPassword ? 'text' : 'password'}
-                    placeholder="Digite sua senha"
-                    value={signInData.password}
-                    onChange={e =>
-                      setSignInData({ ...signInData, password: e.target.value })
-                    }
-                    className="pl-10 pr-10"
-                    required
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setShowSignInPassword(!showSignInPassword)}
-                    className="absolute right-3 top-3 text-gray-400 hover:text-gray-600 transition-colors"
-                    tabIndex={-1}
-                  >
-                    {showSignInPassword ? (
-                      <EyeOff className="h-4 w-4" />
-                    ) : (
-                      <Eye className="h-4 w-4" />
-                    )}
-                  </button>
-                </div>
-              </div>
+                <FormField
+                  control={signInForm.control}
+                  name="password"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Senha</FormLabel>
+                      <FormControl>
+                        <div className="relative">
+                          <Lock className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+                          <Input
+                            type={showSignInPassword ? 'text' : 'password'}
+                            placeholder="Digite sua senha"
+                            className="pl-10 pr-10"
+                            {...field}
+                          />
+                          <button
+                            type="button"
+                            onClick={() => setShowSignInPassword(!showSignInPassword)}
+                            className="absolute right-3 top-3 text-gray-400 hover:text-gray-600 transition-colors"
+                            tabIndex={-1}
+                          >
+                            {showSignInPassword ? (
+                              <EyeOff className="h-4 w-4" />
+                            ) : (
+                              <Eye className="h-4 w-4" />
+                            )}
+                          </button>
+                        </div>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
 
-              <Button type="submit" className="w-full" disabled={isLoading}>
-                {isLoading ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Entrando...
-                  </>
-                ) : (
-                  'Entrar'
-                )}
-              </Button>
-            </form>
+                <Button type="submit" className="w-full" disabled={isLoading}>
+                  {isLoading ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Entrando...
+                    </>
+                  ) : (
+                    'Entrar'
+                  )}
+                </Button>
+              </form>
+            </Form>
           </TabsContent>
 
           {/* Sign Up Tab */}
           <TabsContent value="signup" className="space-y-4">
-            <form onSubmit={handleSignUp} className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="signup-name">Nome Completo</Label>
-                <Input
-                  id="signup-name"
-                  type="text"
-                  placeholder="Seu nome completo"
-                  value={signUpData.name}
-                  onChange={e =>
-                    setSignUpData({ ...signUpData, name: e.target.value })
-                  }
-                  required
+            <Form {...signUpForm}>
+              <form onSubmit={signUpForm.handleSubmit(handleSignUp)} className="space-y-4">
+                <FormField
+                  control={signUpForm.control}
+                  name="name"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Nome Completo</FormLabel>
+                      <FormControl>
+                        <Input placeholder="Seu nome completo" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
                 />
-              </div>
 
-              <div className="space-y-2">
-                <Label htmlFor="signup-username">Username</Label>
-                <div className="relative">
-                  <User className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                  <Input
-                    id="signup-username"
-                    type="text"
-                    placeholder="seu_username"
-                    value={signUpData.username}
-                    onChange={e =>
-                      setSignUpData({ ...signUpData, username: e.target.value })
-                    }
-                    className="pl-10"
-                    required
-                  />
-                </div>
-              </div>
+                <FormField
+                  control={signUpForm.control}
+                  name="username"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Username</FormLabel>
+                      <FormControl>
+                        <div className="relative">
+                          <User className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+                          <Input
+                            placeholder="seu_username"
+                            className="pl-10"
+                            {...field}
+                          />
+                        </div>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
 
-              <div className="space-y-2">
-                <Label htmlFor="signup-email">Email</Label>
-                <div className="relative">
-                  <Mail className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                  <Input
-                    id="signup-email"
-                    type="email"
-                    placeholder="seu@email.com"
-                    value={signUpData.email}
-                    onChange={e =>
-                      setSignUpData({ ...signUpData, email: e.target.value })
-                    }
-                    className="pl-10"
-                    required
-                  />
-                </div>
-              </div>
+                <FormField
+                  control={signUpForm.control}
+                  name="email"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Email</FormLabel>
+                      <FormControl>
+                        <div className="relative">
+                          <Mail className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+                          <Input
+                            type="email"
+                            placeholder="seu@email.com"
+                            className="pl-10"
+                            {...field}
+                          />
+                        </div>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
 
-              <div className="space-y-2">
-                <Label htmlFor="signup-phone">Telefone WhatsApp</Label>
-                <div className="relative">
-                  <Phone className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                  <Input
-                    id="signup-phone"
-                    type="tel"
-                    placeholder="+55 11 98765-4321"
-                    value={signUpData.phone || ''}
-                    onChange={e =>
-                      setSignUpData({ ...signUpData, phone: e.target.value })
-                    }
-                    className="pl-10"
-                  />
-                </div>
-              </div>
+                <FormField
+                  control={signUpForm.control}
+                  name="phone"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Telefone WhatsApp (opcional)</FormLabel>
+                      <FormControl>
+                        <div className="relative">
+                          <Phone className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+                          <Input
+                            type="tel"
+                            placeholder="+55 11 98765-4321"
+                            className="pl-10"
+                            {...field}
+                          />
+                        </div>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
 
-              <div className="space-y-2">
-                <Label htmlFor="signup-password">Senha</Label>
-                <div className="relative">
-                  <Lock className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                  <Input
-                    id="signup-password"
-                    type={showSignUpPassword ? 'text' : 'password'}
-                    placeholder="Digite uma senha forte"
-                    value={signUpData.password}
-                    onChange={e =>
-                      setSignUpData({ ...signUpData, password: e.target.value })
-                    }
-                    className="pl-10 pr-10"
-                    required
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setShowSignUpPassword(!showSignUpPassword)}
-                    className="absolute right-3 top-3 text-gray-400 hover:text-gray-600 transition-colors"
-                    tabIndex={-1}
-                  >
-                    {showSignUpPassword ? (
-                      <EyeOff className="h-4 w-4" />
-                    ) : (
-                      <Eye className="h-4 w-4" />
-                    )}
-                  </button>
-                </div>
-              </div>
+                <FormField
+                  control={signUpForm.control}
+                  name="password"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Senha</FormLabel>
+                      <FormControl>
+                        <div className="relative">
+                          <Lock className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+                          <Input
+                            type={showSignUpPassword ? 'text' : 'password'}
+                            placeholder="Digite uma senha forte"
+                            className="pl-10 pr-10"
+                            {...field}
+                          />
+                          <button
+                            type="button"
+                            onClick={() => setShowSignUpPassword(!showSignUpPassword)}
+                            className="absolute right-3 top-3 text-gray-400 hover:text-gray-600 transition-colors"
+                            tabIndex={-1}
+                          >
+                            {showSignUpPassword ? (
+                              <EyeOff className="h-4 w-4" />
+                            ) : (
+                              <Eye className="h-4 w-4" />
+                            )}
+                          </button>
+                        </div>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
 
-              <Button type="submit" className="w-full" disabled={isLoading}>
-                {isLoading ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Criando conta...
-                  </>
-                ) : (
-                  'Criar Conta'
-                )}
-              </Button>
-            </form>
+                <Button type="submit" className="w-full" disabled={isLoading}>
+                  {isLoading ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Criando conta...
+                    </>
+                  ) : (
+                    'Criar Conta'
+                  )}
+                </Button>
+              </form>
+            </Form>
           </TabsContent>
 
           {/* Password Reset Tab */}
           <TabsContent value="reset" className="space-y-4">
-            <form onSubmit={handlePasswordReset} className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="reset-email">Email</Label>
-                <div className="relative">
-                  <Mail className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                  <Input
-                    id="reset-email"
-                    type="email"
-                    placeholder="seu@email.com"
-                    value={resetEmail}
-                    onChange={e => setResetEmail(e.target.value)}
-                    className="pl-10"
-                    required
-                  />
-                </div>
-              </div>
+            <Form {...resetForm}>
+              <form onSubmit={resetForm.handleSubmit(handlePasswordReset)} className="space-y-4">
+                <FormField
+                  control={resetForm.control}
+                  name="email"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Email</FormLabel>
+                      <FormControl>
+                        <div className="relative">
+                          <Mail className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+                          <Input
+                            type="email"
+                            placeholder="seu@email.com"
+                            className="pl-10"
+                            {...field}
+                          />
+                        </div>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
 
-              <Button type="submit" className="w-full" disabled={isLoading}>
-                {isLoading ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Enviando...
-                  </>
-                ) : (
-                  'Enviar Email de Recuperação'
-                )}
-              </Button>
-            </form>
+                <Button type="submit" className="w-full" disabled={isLoading}>
+                  {isLoading ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Enviando...
+                    </>
+                  ) : (
+                    'Enviar Email de Recuperação'
+                  )}
+                </Button>
+              </form>
+            </Form>
           </TabsContent>
         </Tabs>
-
-        {/* Error Alert */}
-        {error && (
-          <Alert variant="destructive">
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
-        )}
-
-        {/* Success Alert */}
-        {success && (
-          <Alert>
-            <AlertDescription>{success}</AlertDescription>
-          </Alert>
-        )}
       </DialogContent>
     </Dialog>
   );

--- a/src/components/auth-modal.tsx
+++ b/src/components/auth-modal.tsx
@@ -275,7 +275,7 @@ export function AuthModal({ isOpen, onClose, redirectUrl }: AuthModalProps) {
                             type="button"
                             onClick={() => setShowSignInPassword(!showSignInPassword)}
                             className="absolute right-3 top-3 text-gray-400 hover:text-gray-600 transition-colors"
-                            tabIndex={-1}
+                            aria-label={showSignInPassword ? 'Ocultar senha' : 'Mostrar senha'}
                           >
                             {showSignInPassword ? (
                               <EyeOff className="h-4 w-4" />
@@ -406,7 +406,7 @@ export function AuthModal({ isOpen, onClose, redirectUrl }: AuthModalProps) {
                             type="button"
                             onClick={() => setShowSignUpPassword(!showSignUpPassword)}
                             className="absolute right-3 top-3 text-gray-400 hover:text-gray-600 transition-colors"
-                            tabIndex={-1}
+                            aria-label={showSignUpPassword ? 'Ocultar senha' : 'Mostrar senha'}
                           >
                             {showSignUpPassword ? (
                               <EyeOff className="h-4 w-4" />

--- a/src/components/confirm-dialog.tsx
+++ b/src/components/confirm-dialog.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { cn } from '@/lib/utils';
+import { Loader2 } from 'lucide-react';
+
+export interface ConfirmDialogProps {
+  /** Controla se o dialog está aberto */
+  open: boolean;
+  /** Callback quando o estado de abertura muda */
+  onOpenChange: (open: boolean) => void;
+  /** Título do dialog */
+  title: string;
+  /** Descrição/mensagem do dialog */
+  description: string;
+  /** Texto do botão de confirmar */
+  confirmLabel?: string;
+  /** Texto do botão de cancelar */
+  cancelLabel?: string;
+  /** Variante do botão de confirmar */
+  variant?: 'default' | 'destructive';
+  /** Callback executado ao confirmar */
+  onConfirm: () => void | Promise<void>;
+  /** Estado de loading do botão de confirmar */
+  loading?: boolean;
+  /** Desabilita o botão de confirmar */
+  disabled?: boolean;
+}
+
+/**
+ * Componente de diálogo de confirmação reutilizável.
+ *
+ * @example
+ * ```tsx
+ * const [open, setOpen] = useState(false);
+ * const [deleting, setDeleting] = useState(false);
+ *
+ * <ConfirmDialog
+ *   open={open}
+ *   onOpenChange={setOpen}
+ *   title="Excluir comunidade"
+ *   description="Tem certeza que deseja excluir esta comunidade? Esta ação não pode ser desfeita."
+ *   confirmLabel="Excluir"
+ *   variant="destructive"
+ *   loading={deleting}
+ *   onConfirm={async () => {
+ *     setDeleting(true);
+ *     await deleteCommunity();
+ *     setDeleting(false);
+ *     setOpen(false);
+ *   }}
+ * />
+ * ```
+ */
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = 'Confirmar',
+  cancelLabel = 'Cancelar',
+  variant = 'default',
+  onConfirm,
+  loading = false,
+  disabled = false,
+}: ConfirmDialogProps) {
+  const handleConfirm = async () => {
+    await onConfirm();
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={loading}>{cancelLabel}</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(e) => {
+              e.preventDefault();
+              handleConfirm();
+            }}
+            disabled={loading || disabled}
+            className={cn(
+              variant === 'destructive' &&
+                'bg-destructive text-destructive-foreground hover:bg-destructive/90'
+            )}
+          >
+            {loading ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Aguarde...
+              </>
+            ) : (
+              confirmLabel
+            )}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/confirm-dialog.tsx
+++ b/src/components/confirm-dialog.tsx
@@ -87,9 +87,9 @@ export function ConfirmDialog({
         <AlertDialogFooter>
           <AlertDialogCancel disabled={loading}>{cancelLabel}</AlertDialogCancel>
           <AlertDialogAction
-            onClick={(e) => {
+            onClick={async (e) => {
               e.preventDefault();
-              handleConfirm();
+              await handleConfirm();
             }}
             disabled={loading || disabled}
             className={cn(

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { AlertTriangle, RefreshCw } from 'lucide-react';
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  /** Componente customizado de fallback */
+  fallback?: ReactNode;
+  /** Callback chamado quando um erro é capturado */
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+/**
+ * Error Boundary para capturar erros em componentes filhos.
+ *
+ * @example
+ * ```tsx
+ * <ErrorBoundary onError={(error) => logError(error)}>
+ *   <MyComponent />
+ * </ErrorBoundary>
+ * ```
+ */
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    // Log do erro no console
+    console.error('ErrorBoundary caught an error:', error, errorInfo);
+
+    // Callback opcional para logging externo (analytics, Sentry, etc)
+    this.props.onError?.(error, errorInfo);
+  }
+
+  handleReset = (): void => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  handleReload = (): void => {
+    window.location.reload();
+  };
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      // Fallback customizado
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+
+      // Fallback padrão
+      return (
+        <div className="flex min-h-[400px] flex-col items-center justify-center p-8">
+          <div className="flex max-w-md flex-col items-center text-center">
+            <div className="mb-4 rounded-full bg-destructive/10 p-4">
+              <AlertTriangle className="h-8 w-8 text-destructive" />
+            </div>
+
+            <h2 className="mb-2 text-xl font-semibold">
+              Ops! Algo deu errado
+            </h2>
+
+            <p className="mb-6 text-muted-foreground">
+              Ocorreu um erro inesperado. Você pode tentar novamente ou
+              recarregar a página.
+            </p>
+
+            {process.env.NODE_ENV === 'development' && this.state.error && (
+              <details className="mb-6 w-full rounded-lg border bg-muted/50 p-4 text-left">
+                <summary className="cursor-pointer text-sm font-medium">
+                  Detalhes do erro (desenvolvimento)
+                </summary>
+                <pre className="mt-2 overflow-x-auto text-xs text-destructive">
+                  {this.state.error.message}
+                  {'\n\n'}
+                  {this.state.error.stack}
+                </pre>
+              </details>
+            )}
+
+            <div className="flex gap-3">
+              <Button variant="outline" onClick={this.handleReset}>
+                <RefreshCw className="mr-2 h-4 w-4" />
+                Tentar novamente
+              </Button>
+              <Button onClick={this.handleReload}>
+                Recarregar página
+              </Button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+/**
+ * HOC para envolver componentes com Error Boundary
+ */
+export function withErrorBoundary<P extends object>(
+  WrappedComponent: React.ComponentType<P>,
+  fallback?: ReactNode
+) {
+  return function WithErrorBoundaryWrapper(props: P) {
+    return (
+      <ErrorBoundary fallback={fallback}>
+        <WrappedComponent {...props} />
+      </ErrorBoundary>
+    );
+  };
+}

--- a/src/components/event-registration-form.tsx
+++ b/src/components/event-registration-form.tsx
@@ -3,7 +3,6 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
-import * as z from 'zod';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -22,28 +21,16 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/sheet';
-
-// International phone: at least 8 digits
-const phoneRegex = /^\+?[\d\s()-]{8,20}$/;
-
-const formSchema = z.object({
-  fullName: z.string().min(3, {
-    message: 'Nome completo deve ter no mínimo 3 caracteres.',
-  }),
-  email: z.string().email({
-    message: 'Email inválido.',
-  }),
-  phone: z.string().regex(phoneRegex, {
-    message: 'Informe um número válido com código do país (ex: +55 11 98765-4321).',
-  }),
-});
-
-type FormValues = z.infer<typeof formSchema>;
+import { useToast } from '@/hooks/use-toast';
+import {
+  eventRegistrationSchema,
+  type EventRegistrationFormValues,
+} from '@/lib/schemas';
 
 interface EventRegistrationFormProps {
   isOpen: boolean;
   onClose: () => void;
-  onSubmit: (data: FormValues) => void | Promise<void>;
+  onSubmit: (data: EventRegistrationFormValues) => void | Promise<void>;
   eventTitle?: string;
 }
 
@@ -54,9 +41,10 @@ export function EventRegistrationForm({
   eventTitle = 'este evento',
 }: EventRegistrationFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const { toast } = useToast();
 
-  const form = useForm<FormValues>({
-    resolver: zodResolver(formSchema),
+  const form = useForm<EventRegistrationFormValues>({
+    resolver: zodResolver(eventRegistrationSchema),
     defaultValues: {
       fullName: '',
       email: '',
@@ -64,14 +52,23 @@ export function EventRegistrationForm({
     },
   });
 
-  const handleSubmit = async (data: FormValues) => {
+  const handleSubmit = async (data: EventRegistrationFormValues) => {
     setIsSubmitting(true);
     try {
       await onSubmit(data);
       form.reset();
       onClose();
+      toast({
+        title: 'Inscrição realizada!',
+        description: 'Você foi inscrito com sucesso no evento.',
+      });
     } catch (error) {
       console.error('Error submitting form:', error);
+      toast({
+        variant: 'destructive',
+        title: 'Erro na inscrição',
+        description: error instanceof Error ? error.message : 'Não foi possível realizar a inscrição. Tente novamente.',
+      });
     } finally {
       setIsSubmitting(false);
     }

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -105,12 +105,20 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [state, dispatch] = useReducer(authReducer, initialState);
 
-  const [signInMutation] = useMutation<SignInResponse>(SIGN_IN);
-  const [signUpMutation] = useMutation<SignUpResponse>(SIGN_UP);
-  const [forwardPasswordMutation] =
-    useMutation<ForwardPasswordResponse>(FORWARD_PASSWORD);
-  const [resetPasswordMutation] =
-    useMutation<ResetPasswordResponse>(RESET_PASSWORD);
+  const [signInMutation] = useMutation<SignInResponse>(SIGN_IN, {
+    errorPolicy: 'all',
+  });
+  const [signUpMutation] = useMutation<SignUpResponse>(SIGN_UP, {
+    errorPolicy: 'all',
+  });
+  const [forwardPasswordMutation] = useMutation<ForwardPasswordResponse>(
+    FORWARD_PASSWORD,
+    { errorPolicy: 'all' }
+  );
+  const [resetPasswordMutation] = useMutation<ResetPasswordResponse>(
+    RESET_PASSWORD,
+    { errorPolicy: 'all' }
+  );
   const [updateUserPhoneMutation] = useMutation(UPDATE_USER_PHONE);
 
   // Load auth data from localStorage on mount
@@ -206,28 +214,30 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const signIn = async (input: SignInInput) => {
     dispatch({ type: 'AUTH_START' });
     try {
-      const { data } = await signInMutation({ variables: input });
+      const result = await signInMutation({ variables: input });
 
-      if (data?.signIn?.token) {
-        // Use the actual user data returned by the BFF
+      if (result.errors && result.errors.length > 0) {
+        throw new Error(result.errors[0].message);
+      }
+
+      if (result.data?.signIn?.token) {
         const user: User = {
-          id: data.signIn.id || undefined,
-          email: data.signIn.email || input.identifier,
-          username: data.signIn.username || input.identifier.split('@')[0],
-          name: data.signIn.name || undefined,
-          phone: data.signIn.phone || undefined,
+          id: result.data.signIn.id || undefined,
+          email: result.data.signIn.email || input.identifier,
+          username: result.data.signIn.username || input.identifier.split('@')[0],
+          name: result.data.signIn.name || undefined,
+          phone: result.data.signIn.phone || undefined,
         };
 
-        saveToStorage(user, data.signIn.token);
+        saveToStorage(user, result.data.signIn.token);
         dispatch({
           type: 'AUTH_SUCCESS',
-          payload: { user, token: data.signIn.token },
+          payload: { user, token: result.data.signIn.token },
         });
       } else {
         throw new Error('Invalid response');
       }
     } catch (error) {
-      console.error('Sign in error:', error);
       dispatch({ type: 'AUTH_ERROR' });
       throw error;
     }
@@ -236,18 +246,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const signUp = async (input: SignUpInput) => {
     dispatch({ type: 'AUTH_START' });
     try {
-      const { data } = await signUpMutation({ variables: { input } });
+      const result = await signUpMutation({ variables: { input } });
 
-      if (data?.signUp) {
-        // After signup, user needs to sign in
+      if (result.errors && result.errors.length > 0) {
+        throw new Error(result.errors[0].message);
+      }
+
+      if (result.data?.signUp) {
         dispatch({ type: 'AUTH_ERROR' });
-        // You could automatically sign them in here if you want
-        // await signIn({ identifier: input.email, password: input.password });
       } else {
-        throw new Error('Invalid response');
+        throw new Error('Erro ao criar conta. Tente novamente.');
       }
     } catch (error) {
-      console.error('Sign up error:', error);
       dispatch({ type: 'AUTH_ERROR' });
       throw error;
     }
@@ -263,18 +273,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const forwardPassword = async (email: string) => {
     try {
-      await forwardPasswordMutation({ variables: { email } });
+      const result = await forwardPasswordMutation({ variables: { email } });
+      if (result.errors && result.errors.length > 0) {
+        throw new Error(result.errors[0].message);
+      }
     } catch (error) {
-      console.error('Forward password error:', error);
       throw error;
     }
   };
 
   const resetPassword = async (code: string, password: string, passwordConfirmation: string) => {
     try {
-      await resetPasswordMutation({ variables: { code, password, passwordConfirmation } });
+      const result = await resetPasswordMutation({ variables: { code, password, passwordConfirmation } });
+      if (result.errors && result.errors.length > 0) {
+        throw new Error(result.errors[0].message);
+      }
     } catch (error) {
-      console.error('Reset password error:', error);
       throw error;
     }
   };

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -119,7 +119,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     RESET_PASSWORD,
     { errorPolicy: 'all' }
   );
-  const [updateUserPhoneMutation] = useMutation(UPDATE_USER_PHONE);
+  const [updateUserPhoneMutation] = useMutation(UPDATE_USER_PHONE, {
+    errorPolicy: 'none',
+  });
 
   // Load auth data from localStorage on mount
   useEffect(() => {

--- a/src/lib/apollo-client.ts
+++ b/src/lib/apollo-client.ts
@@ -1,4 +1,9 @@
-import { ApolloClient, InMemoryCache, createHttpLink } from '@apollo/client';
+import {
+  ApolloClient,
+  InMemoryCache,
+  createHttpLink,
+  ApolloLink,
+} from '@apollo/client';
 import { setContext } from '@apollo/client/link/context';
 import { onError } from '@apollo/client/link/error';
 import { isTokenExpired } from './jwt';
@@ -45,24 +50,21 @@ function createApolloClient() {
     };
   });
 
-  // Error handling link
   const errorLink = onError(({ graphQLErrors, networkError }) => {
-    if (graphQLErrors) {
-      graphQLErrors.forEach(({ message, locations, path }) => {
-        console.error(
-          `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`
-        );
-      });
-    }
-
-    if (networkError) {
-      console.error(`[Network error]: ${networkError}`);
+    if (process.env.NODE_ENV === 'development') {
+      if (graphQLErrors) {
+        graphQLErrors.forEach(({ message, path }) => {
+          console.error(`[GraphQL error]: ${message} (path: ${path})`);
+        });
+      }
+      if (networkError) {
+        console.error(`[Network error]: ${networkError}`);
+      }
     }
   });
 
-  // Criação do cliente Apollo
   return new ApolloClient({
-    link: errorLink.concat(authLink.concat(httpLink)),
+    link: ApolloLink.from([errorLink, authLink, httpLink]),
     cache: new InMemoryCache({
       typePolicies: {
         Query: {
@@ -83,11 +85,14 @@ function createApolloClient() {
     }),
     defaultOptions: {
       watchQuery: {
-        errorPolicy: 'ignore',
+        errorPolicy: 'all',
         notifyOnNetworkStatusChange: true,
       },
       query: {
-        errorPolicy: 'ignore',
+        errorPolicy: 'all',
+      },
+      mutate: {
+        errorPolicy: 'all',
       },
     },
   });

--- a/src/lib/schemas/auth.schema.ts
+++ b/src/lib/schemas/auth.schema.ts
@@ -1,27 +1,17 @@
 import { z } from 'zod';
 
-// Regex para senha forte: mínimo 8 caracteres, 1 maiúscula, 1 número
 const passwordRegex = /^(?=.*[A-Z])(?=.*\d).{8,}$/;
 
-/**
- * Schema para email
- */
 export const emailSchema = z
   .string()
   .min(1, 'Email é obrigatório.')
   .email('Email inválido.');
 
-/**
- * Schema para senha simples (login)
- */
 export const passwordSchema = z
   .string()
   .min(1, 'Senha é obrigatória.')
   .min(6, 'Senha deve ter no mínimo 6 caracteres.');
 
-/**
- * Schema para senha forte (cadastro)
- */
 export const strongPasswordSchema = z
   .string()
   .min(1, 'Senha é obrigatória.')
@@ -31,18 +21,12 @@ export const strongPasswordSchema = z
     'Senha deve conter pelo menos 1 letra maiúscula e 1 número.'
   );
 
-/**
- * Schema para username
- */
 export const usernameSchema = z
   .string()
   .min(3, 'Username deve ter no mínimo 3 caracteres.')
   .max(30, 'Username deve ter no máximo 30 caracteres.')
   .regex(/^[a-zA-Z0-9_]+$/, 'Username pode conter apenas letras, números e _');
 
-/**
- * Schema para login (identifier pode ser email ou username)
- */
 export const signInSchema = z.object({
   identifier: z.string().min(1, 'Email ou username é obrigatório.'),
   password: passwordSchema,
@@ -50,9 +34,6 @@ export const signInSchema = z.object({
 
 export type SignInFormValues = z.infer<typeof signInSchema>;
 
-/**
- * Schema para cadastro
- */
 export const signUpSchema = z.object({
   email: emailSchema,
   username: usernameSchema,
@@ -63,18 +44,12 @@ export const signUpSchema = z.object({
 
 export type SignUpFormValues = z.infer<typeof signUpSchema>;
 
-/**
- * Schema para recuperação de senha
- */
 export const resetPasswordSchema = z.object({
   email: emailSchema,
 });
 
 export type ResetPasswordFormValues = z.infer<typeof resetPasswordSchema>;
 
-/**
- * Schema para alterar senha
- */
 export const changePasswordSchema = z
   .object({
     currentPassword: passwordSchema,

--- a/src/lib/schemas/auth.schema.ts
+++ b/src/lib/schemas/auth.schema.ts
@@ -1,0 +1,89 @@
+import { z } from 'zod';
+
+// Regex para senha forte: mínimo 8 caracteres, 1 maiúscula, 1 número
+const passwordRegex = /^(?=.*[A-Z])(?=.*\d).{8,}$/;
+
+/**
+ * Schema para email
+ */
+export const emailSchema = z
+  .string()
+  .min(1, 'Email é obrigatório.')
+  .email('Email inválido.');
+
+/**
+ * Schema para senha simples (login)
+ */
+export const passwordSchema = z
+  .string()
+  .min(1, 'Senha é obrigatória.')
+  .min(6, 'Senha deve ter no mínimo 6 caracteres.');
+
+/**
+ * Schema para senha forte (cadastro)
+ */
+export const strongPasswordSchema = z
+  .string()
+  .min(1, 'Senha é obrigatória.')
+  .min(8, 'Senha deve ter no mínimo 8 caracteres.')
+  .regex(
+    passwordRegex,
+    'Senha deve conter pelo menos 1 letra maiúscula e 1 número.'
+  );
+
+/**
+ * Schema para username
+ */
+export const usernameSchema = z
+  .string()
+  .min(3, 'Username deve ter no mínimo 3 caracteres.')
+  .max(30, 'Username deve ter no máximo 30 caracteres.')
+  .regex(/^[a-zA-Z0-9_]+$/, 'Username pode conter apenas letras, números e _');
+
+/**
+ * Schema para login (identifier pode ser email ou username)
+ */
+export const signInSchema = z.object({
+  identifier: z.string().min(1, 'Email ou username é obrigatório.'),
+  password: passwordSchema,
+});
+
+export type SignInFormValues = z.infer<typeof signInSchema>;
+
+/**
+ * Schema para cadastro
+ */
+export const signUpSchema = z.object({
+  email: emailSchema,
+  username: usernameSchema,
+  name: z.string().min(2, 'Nome deve ter no mínimo 2 caracteres.'),
+  password: strongPasswordSchema,
+  phone: z.string().optional(),
+});
+
+export type SignUpFormValues = z.infer<typeof signUpSchema>;
+
+/**
+ * Schema para recuperação de senha
+ */
+export const resetPasswordSchema = z.object({
+  email: emailSchema,
+});
+
+export type ResetPasswordFormValues = z.infer<typeof resetPasswordSchema>;
+
+/**
+ * Schema para alterar senha
+ */
+export const changePasswordSchema = z
+  .object({
+    currentPassword: passwordSchema,
+    newPassword: strongPasswordSchema,
+    confirmNewPassword: z.string().min(1, 'Confirmação de senha é obrigatória.'),
+  })
+  .refine((data) => data.newPassword === data.confirmNewPassword, {
+    message: 'As senhas não coincidem.',
+    path: ['confirmNewPassword'],
+  });
+
+export type ChangePasswordFormValues = z.infer<typeof changePasswordSchema>;

--- a/src/lib/schemas/community.schema.ts
+++ b/src/lib/schemas/community.schema.ts
@@ -1,0 +1,82 @@
+import { z } from 'zod';
+
+// Regex para slug: apenas letras minúsculas, números e hífens
+const slugRegex = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/**
+ * Schema para título
+ */
+export const titleSchema = z
+  .string()
+  .min(1, 'Título é obrigatório.')
+  .min(2, 'Título deve ter no mínimo 2 caracteres.')
+  .max(100, 'Título deve ter no máximo 100 caracteres.');
+
+/**
+ * Schema para slug
+ */
+export const slugSchema = z
+  .string()
+  .min(1, 'Slug é obrigatório.')
+  .min(2, 'Slug deve ter no mínimo 2 caracteres.')
+  .max(100, 'Slug deve ter no máximo 100 caracteres.')
+  .regex(
+    slugRegex,
+    'Slug deve conter apenas letras minúsculas, números e hífens.'
+  );
+
+/**
+ * Schema para descrição curta
+ */
+export const shortDescriptionSchema = z
+  .string()
+  .max(200, 'Descrição curta deve ter no máximo 200 caracteres.')
+  .optional();
+
+/**
+ * Schema para descrição completa
+ */
+export const fullDescriptionSchema = z
+  .string()
+  .max(5000, 'Descrição deve ter no máximo 5000 caracteres.')
+  .optional();
+
+/**
+ * Schema para criar comunidade
+ */
+export const createCommunitySchema = z.object({
+  title: titleSchema,
+  slug: slugSchema,
+  short_description: shortDescriptionSchema,
+});
+
+export type CreateCommunityFormValues = z.infer<typeof createCommunitySchema>;
+
+/**
+ * Schema para editar comunidade (todos os campos)
+ */
+export const editCommunitySchema = z.object({
+  title: titleSchema,
+  slug: slugSchema,
+  short_description: shortDescriptionSchema,
+  full_description: fullDescriptionSchema,
+  members_quantity: z
+    .number()
+    .int('Quantidade deve ser um número inteiro.')
+    .min(0, 'Quantidade não pode ser negativa.')
+    .optional(),
+});
+
+export type EditCommunityFormValues = z.infer<typeof editCommunitySchema>;
+
+/**
+ * Helper para gerar slug a partir do título
+ */
+export function generateSlugFromTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '') // Remove acentos
+    .replace(/[^a-z0-9]+/g, '-') // Substitui caracteres especiais por hífen
+    .replace(/(^-|-$)+/g, ''); // Remove hífens do início e fim
+}

--- a/src/lib/schemas/community.schema.ts
+++ b/src/lib/schemas/community.schema.ts
@@ -1,20 +1,13 @@
 import { z } from 'zod';
 
-// Regex para slug: apenas letras minúsculas, números e hífens
 const slugRegex = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
-/**
- * Schema para título
- */
 export const titleSchema = z
   .string()
   .min(1, 'Título é obrigatório.')
   .min(2, 'Título deve ter no mínimo 2 caracteres.')
   .max(100, 'Título deve ter no máximo 100 caracteres.');
 
-/**
- * Schema para slug
- */
 export const slugSchema = z
   .string()
   .min(1, 'Slug é obrigatório.')
@@ -25,25 +18,16 @@ export const slugSchema = z
     'Slug deve conter apenas letras minúsculas, números e hífens.'
   );
 
-/**
- * Schema para descrição curta
- */
 export const shortDescriptionSchema = z
   .string()
   .max(200, 'Descrição curta deve ter no máximo 200 caracteres.')
   .optional();
 
-/**
- * Schema para descrição completa
- */
 export const fullDescriptionSchema = z
   .string()
   .max(5000, 'Descrição deve ter no máximo 5000 caracteres.')
   .optional();
 
-/**
- * Schema para criar comunidade
- */
 export const createCommunitySchema = z.object({
   title: titleSchema,
   slug: slugSchema,
@@ -52,9 +36,6 @@ export const createCommunitySchema = z.object({
 
 export type CreateCommunityFormValues = z.infer<typeof createCommunitySchema>;
 
-/**
- * Schema para editar comunidade (todos os campos)
- */
 export const editCommunitySchema = z.object({
   title: titleSchema,
   slug: slugSchema,
@@ -69,9 +50,6 @@ export const editCommunitySchema = z.object({
 
 export type EditCommunityFormValues = z.infer<typeof editCommunitySchema>;
 
-/**
- * Helper para gerar slug a partir do título
- */
 export function generateSlugFromTitle(title: string): string {
   return title
     .toLowerCase()

--- a/src/lib/schemas/event.schema.ts
+++ b/src/lib/schemas/event.schema.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { slugSchema, titleSchema } from './community.schema';
 
 export const dateSchema = z.coerce.date({
   required_error: 'Data é obrigatória.',

--- a/src/lib/schemas/event.schema.ts
+++ b/src/lib/schemas/event.schema.ts
@@ -1,0 +1,142 @@
+import { z } from 'zod';
+import { slugSchema, titleSchema } from './community.schema';
+
+/**
+ * Schema para data
+ */
+export const dateSchema = z.coerce.date({
+  required_error: 'Data é obrigatória.',
+  invalid_type_error: 'Data inválida.',
+});
+
+/**
+ * Schema para data opcional
+ */
+export const optionalDateSchema = z.coerce.date().optional().nullable();
+
+/**
+ * Schema para número de vagas
+ */
+export const maxSlotsSchema = z
+  .number()
+  .int('Número de vagas deve ser inteiro.')
+  .min(1, 'Evento deve ter pelo menos 1 vaga.')
+  .max(100000, 'Número de vagas muito alto.');
+
+/**
+ * Schema para criar evento (admin)
+ */
+export const createEventSchema = z.object({
+  title: z.string().min(2, { message: 'O título deve ter pelo menos 2 caracteres.' }),
+  slug: z.string().min(2, { message: 'O slug deve ter pelo menos 2 caracteres.' }),
+  start_date: z.string({ required_error: 'A data de início é obrigatória.' }),
+  end_date: z.string({ required_error: 'A data de término é obrigatória.' }),
+  max_slots: z.coerce.number().min(1, { message: 'O número de vagas deve ser pelo menos 1.' }),
+  pixai_token_integration: z.string().optional(),
+  is_online: z.boolean().optional(),
+  call_link: z.string().optional(),
+  description: z.any().optional(),
+  location: z.any().optional(),
+  communityId: z.string().optional(),
+  talks: z.array(z.any()).optional(),
+  products: z.array(z.any()).optional(),
+});
+
+export type CreateEventFormValues = z.infer<typeof createEventSchema>;
+
+/**
+ * Schema para editar evento
+ */
+export const editEventSchema = createEventSchema;
+
+export type EditEventFormValues = z.infer<typeof editEventSchema>;
+
+/**
+ * Schema para talk/palestra (admin)
+ */
+export const talkSchema = z.object({
+  title: z.string().min(2, 'O título é obrigatório.'),
+  subtitle: z.string().optional(),
+  description: z.any().optional(),
+  occur_date: z.string().min(1, 'A data é obrigatória.'),
+  room_description: z.string().optional(),
+  speakerIds: z.array(z.string()).default([]),
+});
+
+export type TalkFormValues = z.infer<typeof talkSchema>;
+
+/**
+ * Schema para palestrante (admin)
+ */
+export const speakerSchema = z.object({
+  name: z.string().min(2, 'O nome deve ter pelo menos 2 caracteres.'),
+  biography: z.any().optional(),
+});
+
+export type SpeakerFormValues = z.infer<typeof speakerSchema>;
+
+/**
+ * Schema para localização (admin)
+ */
+export const locationSchema = z.object({
+  title: z.string().min(2, 'O título deve ter pelo menos 2 caracteres.'),
+  region: z.string().min(2, 'A região é obrigatória.'),
+  latitude: z.coerce.number().optional(),
+  longitude: z.coerce.number().optional(),
+  google_maps_url: z.string().url('URL inválida').optional().or(z.literal('')),
+  full_address: z.string().min(5, 'O endereço deve ser completo.'),
+  city: z.string().min(2, 'A cidade é obrigatória.'),
+});
+
+export type LocationFormValues = z.infer<typeof locationSchema>;
+
+/**
+ * Schema para lote de ingressos (batch)
+ */
+export const batchSchema = z.object({
+  batch_number: z.coerce.number().min(1, 'Número do lote obrigatório.'),
+  value: z.coerce.number().min(0, 'Valor deve ser positivo.'),
+  max_quantity: z.coerce.number().min(1, 'Quantidade deve ser informada.').optional(),
+  valid_from: z.string().min(1, 'Data de início obrigatória.'),
+  valid_until: z.string().min(1, 'Data de fim obrigatória.'),
+  enabled: z.boolean().default(true),
+  half_price_eligible: z.boolean().default(false),
+});
+
+export type BatchFormValues = z.infer<typeof batchSchema>;
+
+/**
+ * Schema para produto
+ */
+export const productSchema = z.object({
+  name: z.string().min(2, 'O nome do produto é obrigatório.'),
+  enabled: z.boolean().default(true),
+});
+
+export type ProductFormValues = z.infer<typeof productSchema>;
+
+/**
+ * Schema para sessão de votação
+ */
+export const votingSessionSchema = z.object({
+  title: z.string().min(2, { message: 'O título deve ter pelo menos 2 caracteres.' }),
+  description: z.string().optional(),
+  event_id: z.string().optional(),
+  status: z.enum(['open', 'closed', 'archived']),
+  max_votes_per_user: z.coerce.number().min(1, {
+    message: 'O número de votos por usuário deve ser pelo menos 1.',
+  }),
+});
+
+export type VotingSessionFormValues = z.infer<typeof votingSessionSchema>;
+
+/**
+ * Schema para opção de votação
+ */
+export const votingOptionSchema = z.object({
+  name: z.string().min(2, 'O nome é obrigatório.'),
+  description: z.string().optional(),
+  pitch_order: z.coerce.number().min(1, 'A ordem é obrigatória.'),
+});
+
+export type VotingOptionFormValues = z.infer<typeof votingOptionSchema>;

--- a/src/lib/schemas/event.schema.ts
+++ b/src/lib/schemas/event.schema.ts
@@ -1,31 +1,19 @@
 import { z } from 'zod';
 import { slugSchema, titleSchema } from './community.schema';
 
-/**
- * Schema para data
- */
 export const dateSchema = z.coerce.date({
   required_error: 'Data é obrigatória.',
   invalid_type_error: 'Data inválida.',
 });
 
-/**
- * Schema para data opcional
- */
 export const optionalDateSchema = z.coerce.date().optional().nullable();
 
-/**
- * Schema para número de vagas
- */
 export const maxSlotsSchema = z
   .number()
   .int('Número de vagas deve ser inteiro.')
   .min(1, 'Evento deve ter pelo menos 1 vaga.')
   .max(100000, 'Número de vagas muito alto.');
 
-/**
- * Schema para criar evento (admin)
- */
 export const createEventSchema = z.object({
   title: z.string().min(2, { message: 'O título deve ter pelo menos 2 caracteres.' }),
   slug: z.string().min(2, { message: 'O slug deve ter pelo menos 2 caracteres.' }),
@@ -44,16 +32,10 @@ export const createEventSchema = z.object({
 
 export type CreateEventFormValues = z.infer<typeof createEventSchema>;
 
-/**
- * Schema para editar evento
- */
 export const editEventSchema = createEventSchema;
 
 export type EditEventFormValues = z.infer<typeof editEventSchema>;
 
-/**
- * Schema para talk/palestra (admin)
- */
 export const talkSchema = z.object({
   title: z.string().min(2, 'O título é obrigatório.'),
   subtitle: z.string().optional(),
@@ -65,9 +47,6 @@ export const talkSchema = z.object({
 
 export type TalkFormValues = z.infer<typeof talkSchema>;
 
-/**
- * Schema para palestrante (admin)
- */
 export const speakerSchema = z.object({
   name: z.string().min(2, 'O nome deve ter pelo menos 2 caracteres.'),
   biography: z.any().optional(),
@@ -75,9 +54,6 @@ export const speakerSchema = z.object({
 
 export type SpeakerFormValues = z.infer<typeof speakerSchema>;
 
-/**
- * Schema para localização (admin)
- */
 export const locationSchema = z.object({
   title: z.string().min(2, 'O título deve ter pelo menos 2 caracteres.'),
   region: z.string().min(2, 'A região é obrigatória.'),
@@ -90,9 +66,6 @@ export const locationSchema = z.object({
 
 export type LocationFormValues = z.infer<typeof locationSchema>;
 
-/**
- * Schema para lote de ingressos (batch)
- */
 export const batchSchema = z.object({
   batch_number: z.coerce.number().min(1, 'Número do lote obrigatório.'),
   value: z.coerce.number().min(0, 'Valor deve ser positivo.'),
@@ -105,9 +78,6 @@ export const batchSchema = z.object({
 
 export type BatchFormValues = z.infer<typeof batchSchema>;
 
-/**
- * Schema para produto
- */
 export const productSchema = z.object({
   name: z.string().min(2, 'O nome do produto é obrigatório.'),
   enabled: z.boolean().default(true),
@@ -115,9 +85,6 @@ export const productSchema = z.object({
 
 export type ProductFormValues = z.infer<typeof productSchema>;
 
-/**
- * Schema para sessão de votação
- */
 export const votingSessionSchema = z.object({
   title: z.string().min(2, { message: 'O título deve ter pelo menos 2 caracteres.' }),
   description: z.string().optional(),
@@ -130,9 +97,6 @@ export const votingSessionSchema = z.object({
 
 export type VotingSessionFormValues = z.infer<typeof votingSessionSchema>;
 
-/**
- * Schema para opção de votação
- */
 export const votingOptionSchema = z.object({
   name: z.string().min(2, 'O nome é obrigatório.'),
   description: z.string().optional(),

--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -1,0 +1,78 @@
+/**
+ * Schemas Zod centralizados para validação de formulários
+ *
+ * Uso:
+ * ```typescript
+ * import { signInSchema, createCommunitySchema } from '@/lib/schemas';
+ * import type { SignInFormValues } from '@/lib/schemas';
+ * ```
+ */
+
+// Auth schemas
+export {
+  changePasswordSchema,
+  emailSchema,
+  passwordSchema,
+  resetPasswordSchema,
+  signInSchema,
+  signUpSchema,
+  strongPasswordSchema,
+  usernameSchema,
+  type ChangePasswordFormValues,
+  type ResetPasswordFormValues,
+  type SignInFormValues,
+  type SignUpFormValues,
+} from './auth.schema';
+
+// User schemas
+export {
+  certificateSearchSchema,
+  cpfSchema,
+  eventRegistrationSchema,
+  fullNameSchema,
+  isValidCPF,
+  optionalPhoneSchema,
+  phoneSchema,
+  userProfileSchema,
+  type CertificateSearchFormValues,
+  type EventRegistrationFormValues,
+  type UserProfileFormValues,
+} from './user.schema';
+
+// Community schemas
+export {
+  createCommunitySchema,
+  editCommunitySchema,
+  fullDescriptionSchema,
+  generateSlugFromTitle,
+  shortDescriptionSchema,
+  slugSchema,
+  titleSchema,
+  type CreateCommunityFormValues,
+  type EditCommunityFormValues,
+} from './community.schema';
+
+// Event schemas
+export {
+  batchSchema,
+  createEventSchema,
+  dateSchema,
+  editEventSchema,
+  locationSchema,
+  maxSlotsSchema,
+  optionalDateSchema,
+  productSchema,
+  speakerSchema,
+  talkSchema,
+  votingOptionSchema,
+  votingSessionSchema,
+  type BatchFormValues,
+  type CreateEventFormValues,
+  type EditEventFormValues,
+  type LocationFormValues,
+  type ProductFormValues,
+  type SpeakerFormValues,
+  type TalkFormValues,
+  type VotingOptionFormValues,
+  type VotingSessionFormValues,
+} from './event.schema';

--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -1,14 +1,3 @@
-/**
- * Schemas Zod centralizados para validação de formulários
- *
- * Uso:
- * ```typescript
- * import { signInSchema, createCommunitySchema } from '@/lib/schemas';
- * import type { SignInFormValues } from '@/lib/schemas';
- * ```
- */
-
-// Auth schemas
 export {
   changePasswordSchema,
   emailSchema,

--- a/src/lib/schemas/user.schema.ts
+++ b/src/lib/schemas/user.schema.ts
@@ -1,0 +1,113 @@
+import { z } from 'zod';
+
+// Regex para telefone internacional: +55 11 98765-4321
+const phoneRegex = /^\+?[\d\s()-]{8,20}$/;
+
+/**
+ * Validação de CPF brasileiro
+ * Verifica dígitos verificadores
+ */
+function isValidCPF(cpf: string): boolean {
+  // Remove caracteres não numéricos
+  const cleaned = cpf.replace(/\D/g, '');
+
+  // CPF deve ter 11 dígitos
+  if (cleaned.length !== 11) return false;
+
+  // Verifica se todos os dígitos são iguais
+  if (/^(\d)\1+$/.test(cleaned)) return false;
+
+  // Validação do primeiro dígito verificador
+  let sum = 0;
+  for (let i = 0; i < 9; i++) {
+    sum += parseInt(cleaned.charAt(i)) * (10 - i);
+  }
+  let remainder = (sum * 10) % 11;
+  if (remainder === 10 || remainder === 11) remainder = 0;
+  if (remainder !== parseInt(cleaned.charAt(9))) return false;
+
+  // Validação do segundo dígito verificador
+  sum = 0;
+  for (let i = 0; i < 10; i++) {
+    sum += parseInt(cleaned.charAt(i)) * (11 - i);
+  }
+  remainder = (sum * 10) % 11;
+  if (remainder === 10 || remainder === 11) remainder = 0;
+  if (remainder !== parseInt(cleaned.charAt(10))) return false;
+
+  return true;
+}
+
+/**
+ * Schema para nome completo
+ */
+export const fullNameSchema = z
+  .string()
+  .min(1, 'Nome é obrigatório.')
+  .min(3, 'Nome deve ter no mínimo 3 caracteres.')
+  .max(100, 'Nome deve ter no máximo 100 caracteres.');
+
+/**
+ * Schema para telefone internacional
+ */
+export const phoneSchema = z
+  .string()
+  .min(1, 'Telefone é obrigatório.')
+  .regex(
+    phoneRegex,
+    'Informe um número válido com código do país (ex: +55 11 98765-4321).'
+  );
+
+/**
+ * Schema para telefone opcional
+ */
+export const optionalPhoneSchema = z
+  .string()
+  .regex(phoneRegex, 'Número de telefone inválido.')
+  .optional()
+  .or(z.literal(''));
+
+/**
+ * Schema para CPF brasileiro
+ */
+export const cpfSchema = z
+  .string()
+  .min(1, 'CPF é obrigatório.')
+  .refine(isValidCPF, 'CPF inválido.');
+
+/**
+ * Schema para perfil de usuário
+ */
+export const userProfileSchema = z.object({
+  fullName: fullNameSchema,
+  email: z.string().email('Email inválido.'),
+  phone: optionalPhoneSchema,
+  bio: z.string().max(500, 'Biografia deve ter no máximo 500 caracteres.').optional(),
+});
+
+export type UserProfileFormValues = z.infer<typeof userProfileSchema>;
+
+/**
+ * Schema para registro em evento
+ */
+export const eventRegistrationSchema = z.object({
+  fullName: fullNameSchema,
+  email: z.string().min(1, 'Email é obrigatório.').email('Email inválido.'),
+  phone: phoneSchema,
+});
+
+export type EventRegistrationFormValues = z.infer<typeof eventRegistrationSchema>;
+
+/**
+ * Schema para busca de certificado
+ */
+export const certificateSearchSchema = z.object({
+  identifier: cpfSchema,
+  email: z.string().email('Email inválido.').optional(),
+  phone_number: optionalPhoneSchema,
+});
+
+export type CertificateSearchFormValues = z.infer<typeof certificateSearchSchema>;
+
+// Exporta a função de validação de CPF para uso externo
+export { isValidCPF };

--- a/src/lib/schemas/user.schema.ts
+++ b/src/lib/schemas/user.schema.ts
@@ -1,13 +1,8 @@
 import { z } from 'zod';
 
-// Regex para telefone internacional: +55 11 98765-4321
 const phoneRegex = /^\+?[\d\s()-]{8,20}$/;
 
-/**
- * Validação de CPF brasileiro
- * Verifica dígitos verificadores
- */
-function isValidCPF(cpf: string): boolean {
+export function isValidCPF(cpf: string): boolean {
   // Remove caracteres não numéricos
   const cleaned = cpf.replace(/\D/g, '');
 
@@ -38,18 +33,12 @@ function isValidCPF(cpf: string): boolean {
   return true;
 }
 
-/**
- * Schema para nome completo
- */
 export const fullNameSchema = z
   .string()
   .min(1, 'Nome é obrigatório.')
   .min(3, 'Nome deve ter no mínimo 3 caracteres.')
   .max(100, 'Nome deve ter no máximo 100 caracteres.');
 
-/**
- * Schema para telefone internacional
- */
 export const phoneSchema = z
   .string()
   .min(1, 'Telefone é obrigatório.')
@@ -58,26 +47,17 @@ export const phoneSchema = z
     'Informe um número válido com código do país (ex: +55 11 98765-4321).'
   );
 
-/**
- * Schema para telefone opcional
- */
 export const optionalPhoneSchema = z
   .string()
   .regex(phoneRegex, 'Número de telefone inválido.')
   .optional()
   .or(z.literal(''));
 
-/**
- * Schema para CPF brasileiro
- */
 export const cpfSchema = z
   .string()
   .min(1, 'CPF é obrigatório.')
   .refine(isValidCPF, 'CPF inválido.');
 
-/**
- * Schema para perfil de usuário
- */
 export const userProfileSchema = z.object({
   fullName: fullNameSchema,
   email: z.string().email('Email inválido.'),
@@ -87,9 +67,6 @@ export const userProfileSchema = z.object({
 
 export type UserProfileFormValues = z.infer<typeof userProfileSchema>;
 
-/**
- * Schema para registro em evento
- */
 export const eventRegistrationSchema = z.object({
   fullName: fullNameSchema,
   email: z.string().min(1, 'Email é obrigatório.').email('Email inválido.'),


### PR DESCRIPTION
## Descrição

Refatora o modal de autenticação (login/cadastro/recuperar senha) para usar validação Zod, react-hook-form e feedback via toast.

## Mudanças

### Schemas Zod Centralizados
- `src/lib/schemas/auth.schema.ts`: signIn, signUp, resetPassword, changePassword
- `src/lib/schemas/user.schema.ts`: fullName, phone, cpf, eventRegistration
- `src/lib/schemas/community.schema.ts`: createCommunity com geração de slug
- `src/lib/schemas/event.schema.ts`: createEvent, talk, speaker, location, batch, product, votingSession

### Auth Modal
- Migrado de useState para react-hook-form com zodResolver
- Validação em tempo real com mensagens de erro em português
- Feedback via toast (Sonner) para sucesso e erro
- Tradução automática de mensagens de erro do GraphQL

### Componentes Utilitários
- ConfirmDialog: Substitui window.confirm() por AlertDialog do Radix
- ErrorBoundary: Captura erros React com fallback UI e botão de retry

### Apollo Client
- Corrigido errorPolicy: 'all' para mutations capturarem erros GraphQL

### Forms Admin Refatorados
- Todos os formulários admin agora usam schemas centralizados